### PR TITLE
add browserify support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
+build
+component.json
+components
+Makefile
 test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ build: popover.css index.js template.html components
 components:
 	@component install --dev
 
+build-browserify: index.js template.html node_modules
+	@mkdir -p build
+	@browserify \
+		--require popover \
+		--require ./index.js:confirmation-popover \
+		--outfile build/build.js
+
 clean:
 	rm -fr build components
 
-.PHONY: clean
+.PHONY: clean build
+

--- a/component.json
+++ b/component.json
@@ -9,7 +9,7 @@
     "ui"
   ],
   "dependencies": {
-    "component/inherit": "0.0.3",
+    "component/inherit": "*",
     "component/popover": "*",
     "component/query": "*"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,19 @@
     "component"
   ],
   "dependencies": {
-    "popover-component": "*"
+    "component-inherit": "~0",
+    "component-query": "~0",
+    "popover-component": "^1.1.1"
+  },
+  "browser": {
+    "inherit": "component-inherit",
+    "popover": "popover-component",
+    "query": "component-query"
+  },
+  "browserify": {
+    "transform": [
+      "stringify"
+    ]
   },
   "component": {
     "styles": [
@@ -20,8 +32,12 @@
       "confirmation-popover/template.js": "template.js"
     }
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/component/confirmation-popover.git"
+  },
+  "devDependencies": {
+    "stringify": "^3.1.0"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -30,7 +30,7 @@
     <a href="#" id="auto-title">Auto Title</a>
     <script>
       var Popover = require('confirmation-popover');
-      require('component-popover').effect = 'fade';
+      require('popover').effect = 'fade';
 
       var confirm = new Popover('Are you sure?');
       confirm.show('#auto', function(ok){


### PR DESCRIPTION
similar to component/popover#9

fix deps in package.json, add browser section

make build-browserify target is added as an alternative to component build - mostly to allow for independent testing
